### PR TITLE
Support Swift 6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
 format:
-	mint run --executable swift-format swift-format --recursive --in-place Sources Tests
+	swift format --recursive --in-place Sources Tests

--- a/Sources/TokyoTechWifiKit/Logic/PostURLParser.swift
+++ b/Sources/TokyoTechWifiKit/Logic/PostURLParser.swift
@@ -3,7 +3,7 @@ import Kanna
 
 enum PostURLParser {
     static func parse(htmlDoc: HTMLDocument) throws -> URL {
-        if let url = URL(string: htmlDoc.at_css("form")?["action"] ?? "") {
+        if let action = htmlDoc.at_css("form")?["action"], let url = URL(string: action) {
             return url
         } else {
             throw TokyoTechWifiError.parsePostUrlFailed


### PR DESCRIPTION
- PostURLParserを修正：~環境によっては~ **Linux + Swift 6.0.x では**URL("")がエラーとならないため
    - Swift 5.10.1以前ではURL("")で正しくエラーとなるためにテストが通っていた
    - 検証コード： https://swiftfiddle.com/vhe4g7kwevdb7iricv7vcxuwku
```diff
-    if let url = URL(string: htmlDoc.at_css("form")?["action"] ?? "") {
+    if let action = htmlDoc.at_css("form")?["action"], let url = URL(string: action) {
    return url
} else { ...
```